### PR TITLE
io_queue: Introduce IOPS token bucket

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -189,6 +189,7 @@ public:
 
     void update_shares_for_class(internal::priority_class pc, size_t new_shares);
     future<> update_bandwidth_for_class(internal::priority_class pc, uint64_t new_bandwidth);
+    future<> update_iops_for_class(internal::priority_class pc, uint64_t new_iops);
     void rename_priority_class(internal::priority_class pc, sstring new_name);
     void throttle_priority_class(const priority_class_data& pc) noexcept;
     void unthrottle_priority_class(const priority_class_data& pc) noexcept;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -465,6 +465,8 @@ public:
     /// @private
     future<> update_bandwidth_for_queues(internal::priority_class pc, uint64_t bandwidth);
     /// @private
+    future<> update_iops_for_queues(internal::priority_class pc, uint64_t iops);
+    /// @private
     void rename_queues(internal::priority_class pc, sstring new_name);
     /// @private
     void update_shares_for_queues(internal::priority_class pc, uint32_t shares);

--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -342,7 +342,14 @@ public:
     /// \param bandwidth the new bandwidth value in bytes/second
     /// \return a future that is ready when the bandwidth update is applied
     future<> update_io_bandwidth(uint64_t bandwidth) const;
-
+    /// \brief Updates the current IOPS rate for a given scheduling group
+    ///
+    /// The rate applied is NOT shard-local, instead it is applied so that
+    /// all shards cannot consume more IO operations-per-second
+    ///
+    /// \param iops_rate the new rate value in operations/second
+    /// \return a future that is ready when the op/s update is applied
+    future<> update_io_rate(uint64_t iops_rate) const;
     friend future<scheduling_group> create_scheduling_group(sstring name, sstring shortname, float shares) noexcept;
     friend future<> destroy_scheduling_group(scheduling_group sg) noexcept;
     friend future<> rename_scheduling_group(scheduling_group sg, sstring new_name, sstring new_shortname) noexcept;


### PR DESCRIPTION
Implement an additional token bucket to regulate the IOPS rate across all I/O operations, improving fine-grained control over throughput.